### PR TITLE
Profile window to front

### DIFF
--- a/org/geomapapp/util/GMAProfile.java
+++ b/org/geomapapp/util/GMAProfile.java
@@ -490,8 +490,12 @@ public class GMAProfile implements Overlay, XYPoints {
 					}
 				}
 			}
-		}	
-		if(!dialog.isVisible())dialog.setVisible(true);
+		}
+		if(!dialog.isVisible()) {
+			dialog.setLocation(map.getX(), map.getY()+150);
+			dialog.setVisible(true);
+		}
+		dialog.toFront();
 
 		int dpi = Toolkit.getDefaultToolkit().getScreenResolution();
 		DecimalFormat fmt = new DecimalFormat("#.#");


### PR DESCRIPTION
The profile window now comes back to the front after every time a new profile is drawn. It is also 150px lower on the screen by default.